### PR TITLE
converted window.onClick to window.addEventListener('click', ...

### DIFF
--- a/client/src/components/pages/auth/Login.jsx
+++ b/client/src/components/pages/auth/Login.jsx
@@ -14,12 +14,12 @@ class Login extends Component {
 
   renderAlert() {
     if (this.props.errorMessage) {
-      window.onclick = (event) => {
+      window.addEventListener('click', function (event) {
         let flashMessage = document.getElementById('deleteErrorMessage')
         if (event.target != flashMessage) {
           flashMessage.style.display = "none";
         }
-      }
+      });
       return (
         <div className="error-popover" id="deleteErrorMessage">
           <div className="popover-arrow">

--- a/client/src/components/pages/auth/Signup.jsx
+++ b/client/src/components/pages/auth/Signup.jsx
@@ -14,12 +14,12 @@ class Signup extends Component {
 
   renderAlert() {
     if (this.props.errorMessage) {
-      window.onclick = (event) => {
+      window.addEventListener('click', function (event) {
         let flashMessage = document.getElementById('deleteErrorMessage')
         if (event.target != flashMessage) {
           flashMessage.style.display = "none";
         }
-      }
+      });
       return (
         <div className="error-popover" id="deleteErrorMessage">
           <div className="popover-arrow">


### PR DESCRIPTION
## Purpose
* 2 line fix to convert onClicks to addEventListener('click', ...)s to enable flash messages closeing on mobile

## Approach/Fixes
* It allows closing of flash messages on mobile

## Testing
* Provide instructions on how to test this PR
* Include any required setup
* Include test cases and expected outcome
